### PR TITLE
Feature/#3 ci go tests

### DIFF
--- a/.github/workflows/pr-go-workflow.yaml
+++ b/.github/workflows/pr-go-workflow.yaml
@@ -1,7 +1,7 @@
 name: pr-go-packages
 
 on:
-  pull-request:
+  pull_request:
     branches:
       - main
     paths:


### PR DESCRIPTION
Adds a github actions workflow to run for pull requests that change code in the devlake-go folder.
Vets, checks formatting, builds and tests every package.
Set a max timeout as 20 minutes because by default it is 6 hours and this has bitten me in the past.