### PR TITLE
#3: Limit workflow to run when release is published.

### DIFF
--- a/.github/workflows/release-dora-plugin-frontend-workflow.yaml
+++ b/.github/workflows/release-dora-plugin-frontend-workflow.yaml
@@ -2,6 +2,7 @@ name: Publish Plugin
 on:
   workflow_dispatch:
   release:
+    types: [published]
     branches:
       - main
     paths:

--- a/backstage-plugin/plugins/dora-plugin/package.json
+++ b/backstage-plugin/plugins/dora-plugin/package.json
@@ -4,7 +4,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
+  "private": false,
   "repository": "https://github.com/DevoteamNL/dora-backstage-plugin/",
   "publishConfig": {
     "access": "restricted",


### PR DESCRIPTION
- Allow publishing package by making it public