### PR TITLE
#43: Filter cicd deployments by joining on the repo table instead of …

### DIFF
--- a/devlake-go/api/sql_client/sql_queries/monthly_deployment_count.sql
+++ b/devlake-go/api/sql_client/sql_queries/monthly_deployment_count.sql
@@ -13,7 +13,7 @@ WITH _deployments AS(
             WHERE
                 (
                     :project = ""
-                    OR repos.name LIKE CONCAT('%/', LOWER(:project))
+                    OR LOWER(repos.name) LIKE CONCAT('%/', LOWER(:project))
                 )
                 AND cdc.result = 'SUCCESS'
                 AND cdc.environment = 'PRODUCTION'

--- a/devlake-go/api/sql_client/sql_queries/quarterly_deployment_count.sql
+++ b/devlake-go/api/sql_client/sql_queries/quarterly_deployment_count.sql
@@ -31,7 +31,7 @@ _deployments AS(
             WHERE
                 (
                     :project = ""
-                    OR repos.name LIKE CONCAT('%/', LOWER(:project))
+                    OR LOWER(repos.name) LIKE CONCAT('%/', LOWER(:project))
                 )
                 AND cdc.result = 'SUCCESS'
                 AND cdc.environment = 'PRODUCTION'

--- a/devlake-go/api/sql_client/sql_queries/weekly_deployment_count.sql
+++ b/devlake-go/api/sql_client/sql_queries/weekly_deployment_count.sql
@@ -28,7 +28,7 @@ _deployments AS(
             WHERE
                 (
                     :project = ""
-                    OR repos.name LIKE CONCAT('%/', LOWER(:project))
+                    OR LOWER(repos.name) LIKE CONCAT('%/', LOWER(:project))
                 )
                 AND cdc.result = 'SUCCESS'
                 AND cdc.environment = 'PRODUCTION'


### PR DESCRIPTION
…the project mapping.

- We need to decide whether to match on `repos.name`, `repos.url`, or some partial match of one of them (maybe `repos.name` as backstage namespace + backstage component) 


