### PR TITLE
Fix/#150 Add option to allow native passwords method to be used

### DIFF
--- a/devlake-go/api/sql_client/client.go
+++ b/devlake-go/api/sql_client/client.go
@@ -29,11 +29,11 @@ func New() Client {
 
 func (client Client) connectToDatabase() {
 	cfg := mysql.Config{
-		User:   os.Getenv("DEVLAKE_DBUSER"),
-		Passwd: os.Getenv("DEVLAKE_DBPASS"),
-		Net:    "tcp",
-		Addr:   os.Getenv("DEVLAKE_DBADDRESS"),
-		DBName: os.Getenv("DEVLAKE_DBNAME"),
+		User:                 os.Getenv("DEVLAKE_DBUSER"),
+		Passwd:               os.Getenv("DEVLAKE_DBPASS"),
+		Net:                  "tcp",
+		Addr:                 os.Getenv("DEVLAKE_DBADDRESS"),
+		DBName:               os.Getenv("DEVLAKE_DBNAME"),
 		AllowNativePasswords: true,
 	}
 

--- a/devlake-go/api/sql_client/client.go
+++ b/devlake-go/api/sql_client/client.go
@@ -34,6 +34,7 @@ func (client Client) connectToDatabase() {
 		Net:    "tcp",
 		Addr:   os.Getenv("DEVLAKE_DBADDRESS"),
 		DBName: os.Getenv("DEVLAKE_DBNAME"),
+		AllowNativePasswords: true,
 	}
 
 	var err error


### PR DESCRIPTION
# Description

Add modification suggested by @jtatarik for allowing native password method to be used in MySQL database for Devlake when trying to connect from devlake-go api.

### Issue

This PR addresses issue #150.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/DevoteamNL/opendora/blob/main/CONTRIBUTING.md).**
- [x] **I have ran the linting and formatting scripts to make sure the code is consistently styled.**
- [x] **I have built/compiled and ran the tests to make sure the code works correctly.**
- [x] **I have added or changed tests to cover new or different functionality, where applicable.**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.
