### PR TITLE
Update plugin dependency @mui/x-charts ^6.19.8

### DIFF
--- a/backstage-plugin/plugins/open-dora/package.json
+++ b/backstage-plugin/plugins/open-dora/package.json
@@ -32,7 +32,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
-    "@mui/x-charts": "^6.18.7",
+    "@mui/x-charts": "^6.19.8",
     "i18next": "^23.7.6",
     "react-i18next": "^13.5.0",
     "react-use": "^17.2.4"

--- a/backstage-plugin/yarn.lock
+++ b/backstage-plugin/yarn.lock
@@ -3633,10 +3633,10 @@
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
-"@mui/x-charts@^6.18.7":
-  version "6.18.7"
-  resolved "https://registry.yarnpkg.com/@mui/x-charts/-/x-charts-6.18.7.tgz#3febea719cf007c775946f72dde20304ad2a223e"
-  integrity sha512-s7a24H0vEnOGjLv4DNHsjLAScu6rLHOLDUV5LFe22Kv0//Xl4r8bjmX7BXzy3ma3z9Uy2gw5Ey9ASpi0sQKjeg==
+"@mui/x-charts@^6.19.11":
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/@mui/x-charts/-/x-charts-6.19.8.tgz#df2d4ee0a185d37481928355f69925c8af2c4329"
+  integrity sha512-cjwsCJrUPDlMytJHBV+g3gDoSRURiphjclZs8sRnkZ+h4QbHn24K5QkK4bxEj7aCkO2HVJmDE0aqYEg4BnWCOA==
   dependencies:
     "@babel/runtime" "^7.23.2"
     "@mui/base" "^5.0.0-beta.22"


### PR DESCRIPTION
This will fix prop type warning triggered by hovering over the BarChart component:

```Warning: Failed prop type: Invalid prop `axisData.x.value` supplied to ...```

# Description

Update @mui/x-charts dependency 

### Issue

![invalidProp](https://github.com/DevoteamNL/opendora/assets/132995983/6bb737c2-bc21-4003-8f0f-beb6672213b7)

This PR addresses issue #[issue-number].

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/DevoteamNL/opendora/blob/main/CONTRIBUTING.md).**
- [x] **I have ran the linting and formatting scripts to make sure the code is consistently styled.**
- [x] **I have built/compiled and ran the tests to make sure the code works correctly.**
- [x] **I have added or changed tests to cover new or different functionality, where applicable.**
- [ ] **Create an issue and link to the pull request.**
